### PR TITLE
Add frame_rate attribute to HLS.Variant struct

### DIFF
--- a/lib/hls/variant.ex
+++ b/lib/hls/variant.ex
@@ -18,7 +18,8 @@ defmodule HLS.Variant do
     :codecs,
     :resolution,
     :audio,
-    :subtitles
+    :subtitles,
+    :frame_rate,
   ]
 
   def build(lines) do
@@ -44,7 +45,8 @@ defmodule HLS.Variant do
       codecs: HLS.M3ULine.get_attribute(tag_line, "codecs"),
       resolution: HLS.M3ULine.get_attribute(tag_line, "resolution"),
       audio: HLS.M3ULine.get_attribute(tag_line, "audio"),
-      subtitles: HLS.M3ULine.get_attribute(tag_line, "subtitles")
+      subtitles: HLS.M3ULine.get_attribute(tag_line, "subtitles"),
+      frame_rate: HLS.M3ULine.get_attribute(tag_line, "frame-rate")
     }
   end
 

--- a/test/hls_test.exs
+++ b/test/hls_test.exs
@@ -102,7 +102,7 @@ defmodule HLSTest do
 
   test "builds variant list correctly" do
     master_playlist = """
-    #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=240000,RESOLUTION=396x224
+    #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=240000,RESOLUTION=396x224,FRAME-RATE=24.000
     media.m3u8
     """
 
@@ -114,6 +114,7 @@ defmodule HLSTest do
     assert variant.bandwidth == 240_000
     assert variant.codecs == nil
     assert variant.resolution == "396x224"
+    assert variant.frame_rate == "24.000"
     assert variant.uri == "media.m3u8"
 
     master_playlist = """


### PR DESCRIPTION
Hi Cade! 
Looks like you had added most of the support for frame rates, just curious if there was anything specific holding it up.
Thanks!